### PR TITLE
Svg visualisation with path support

### DIFF
--- a/Coding Challenges/20180907-Weekly/game-server/web-server.rb
+++ b/Coding Challenges/20180907-Weekly/game-server/web-server.rb
@@ -216,16 +216,17 @@ get '/game/v1/map/:timestamp/visualise' do
             mapfilepath = "#{folderpath}/map.json"
             map = JSON.parse(IO.read(mapfilepath))
             pointReprs = map['points'].map { |point|
-              "<div style='width: 4px; height: 4px; position: absolute; bottom: #{(point['coordinates'][1] * 8) + 398}px; left: #{(point['coordinates'][0] * 8) + 398}px; background-color: black'></div>"
+              "<circle cx='#{(point['coordinates'][0] * 8) + 400}' cy='#{400 - (point['coordinates'][1] * 8)}' r='3' fill='black' />"
             }
             <<-eos
               <html>
               <head><title>#{map['mapId']}</title></head>
               <body>
                 <p>#{map['timestamp']}</p>
-                <div style="position: relative; border: solid 1px #ccc; width: 800px; height: 800px; margin: 10px; background-color: #f7f7f7;">
+                <svg style="margin: 10px; background-colour: #f7f7f7; border: solid 1px #ccc;" height="800" width="800">
+                  <rect width="100%" height="100%" fill="#f7f7f7"/>
                   #{pointReprs.join}
-                </div>
+                </svg>
               </body>
               </html>
             eos

--- a/Coding Challenges/20180907-Weekly/game-server/web-server.rb
+++ b/Coding Challenges/20180907-Weekly/game-server/web-server.rb
@@ -204,7 +204,7 @@ get '/game/v1/map/:timestamp' do
     end
 end
 
-get '/game/v1/map/:timestamp/visualise' do
+get '/game/v1/map/:timestamp/visualise(/:ids)?' do
     content_type 'text/html'
     hourcode = params['timestamp']
     if /^\d\d\d\d-\d\d-\d\d-\d\d$/.match(hourcode) then
@@ -216,8 +216,22 @@ get '/game/v1/map/:timestamp/visualise' do
             mapfilepath = "#{folderpath}/map.json"
             map = JSON.parse(IO.read(mapfilepath))
             pointReprs = map['points'].map { |point|
-              "<circle cx='#{(point['coordinates'][0] * 8) + 400}' cy='#{400 - (point['coordinates'][1] * 8)}' r='3' fill='black' />"
+              "<circle cx='#{(point['coordinates'][0] * 8) + 400}' cy='#{400 - (point['coordinates'][1] * 8)}' r='3' fill='black' />\n"
             }
+            if params['ids'] then
+              stops = params['ids'].split(",").each_cons(2)
+              lineReprs = stops.map { |startLbl, finishLbl|
+                start = GameLibrary::getPointForlabelAtMapOrNull(startLbl, map)
+                finish = GameLibrary::getPointForlabelAtMapOrNull(finishLbl, map)
+                if start && finish then
+                  "<line x1='#{(start['coordinates'][0] * 8) + 400}' y1='#{400 - (start['coordinates'][1] * 8)}' x2='#{(finish['coordinates'][0] * 8) + 400}' y2='#{(400 - finish['coordinates'][1] * 8)}' style='stroke:rgb(255,0,0);stroke-width:2' />\n"
+                else
+                  ""
+                end
+              }
+            else
+              lineReprs = []
+            end
             <<-eos
               <html>
               <head><title>#{map['mapId']}</title></head>
@@ -225,6 +239,7 @@ get '/game/v1/map/:timestamp/visualise' do
                 <p>#{map['timestamp']}</p>
                 <svg style="margin: 10px; background-colour: #f7f7f7; border: solid 1px #ccc;" height="800" width="800">
                   <rect width="100%" height="100%" fill="#f7f7f7"/>
+                  #{lineReprs.join}
                   #{pointReprs.join}
                 </svg>
               </body>


### PR DESCRIPTION
Switches to SVG for the visualisation. This makes no difference for the existing map visualisation but allows us to additionally visualise paths. If you append `/label1,label2,etc...` to the visualisation they'll be drawn as well. Here's today's 18:00 solution, visualised.

![screenshot from 2018-09-11 18-57-22](https://user-images.githubusercontent.com/29761/45378144-8f8f9700-b5f4-11e8-8ac7-80bd10783a84.png)
